### PR TITLE
Release vscode-textmate-rstheme 2025.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025.9.0
+
+### Maintenance
+
+- Update development dependencies (`@types/node`) to the latest version (#7).
+- Replace `CLAUDE.md` with `AGENTS.md` (#6).
+
 ## 2025.8.0
 
 ### Improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "textmate-rstheme",
-  "version": "2025.8.0",
+  "version": "2025.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "textmate-rstheme",
-      "version": "2025.8.0",
+      "version": "2025.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textmate-rstheme",
-  "version": "2025.8.0",
+  "version": "2025.9.0",
   "publisher": "nanxstats",
   "author": {
     "name": "Nan Xiao"


### PR DESCRIPTION
This PR updates the changelog and bumps the version number to 2025.9.0.