### PR TITLE
Release vscode-textmate-rstheme 2026.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   ([microsoft/vscode#276781](https://github.com/microsoft/vscode/issues/276781))
   in VS Code 1.108 (#21).
 
+### Maintenance
+
+- Update development dependencies (`@types/node`) to the latest version (#20).
+
 ## 2025.12.0
 
 ### Maintenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "textmate-rstheme",
-  "version": "2025.12.0",
+  "version": "2026.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "textmate-rstheme",
-      "version": "2025.12.0",
+      "version": "2026.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textmate-rstheme",
-  "version": "2025.12.0",
+  "version": "2026.1.0",
   "publisher": "nanxstats",
   "author": {
     "name": "Nan Xiao"


### PR DESCRIPTION
This PR bumps the version number and updates the changelog.